### PR TITLE
mcux_sdk: QN9090: update GPIO_BASE define to GPIO_BASE_MCUX

### DIFF
--- a/mcux/mcux-sdk/devices/QN9090/QN9090.h
+++ b/mcux/mcux-sdk/devices/QN9090/QN9090.h
@@ -5372,11 +5372,11 @@ typedef struct {
 
 /* GPIO - Peripheral instance base addresses */
 /** Peripheral GPIO base address */
-#define GPIO_BASE                                (0x40080000u)
+#define GPIO_BASE_MCUX                           (0x40080000u)
 /** Peripheral GPIO base pointer */
-#define GPIO                                     ((GPIO_Type *)GPIO_BASE)
+#define GPIO                                     ((GPIO_Type *)GPIO_BASE_MCUX)
 /** Array initializer of GPIO peripheral base addresses */
-#define GPIO_BASE_ADDRS                          { GPIO_BASE }
+#define GPIO_BASE_ADDRS                          { GPIO_BASE_MCUX }
 /** Array initializer of GPIO peripheral base pointers */
 #define GPIO_BASE_PTRS                           { GPIO }
 

--- a/mcux/mcux-sdk/devices/QN9090/soc/board.h
+++ b/mcux/mcux-sdk/devices/QN9090/soc/board.h
@@ -184,8 +184,8 @@
                          BIT(IOCON_DBG_PIN+2)|BIT(IOCON_DBG_PIN+3)|\
                          BIT(IOCON_DBG_PIN+4))
 
-#define IODBG_SET_MASK(mask)   ((GPIO_Type *)GPIO_BASE)->SET[0] = mask
-#define IODBG_CLR_MASK(mask)   ((GPIO_Type *)GPIO_BASE)->CLR[0] = mask
+#define IODBG_SET_MASK(mask)   ((GPIO_Type *)GPIO_BASE_MCUX)->SET[0] = mask
+#define IODBG_CLR_MASK(mask)   ((GPIO_Type *)GPIO_BASE_MCUX)->CLR[0] = mask
 
 #define IODBG_SET(pin)   IODBG_SET_MASK(BIT((pin)+IOCON_DBG_PIN))
 #define IODBG_CLR(pin)   IODBG_CLR_MASK(BIT((pin)+IOCON_DBG_PIN))
@@ -346,7 +346,7 @@
 #define ADC_WAIT_TIME_US                           300
 
 /* ADC measurements are done one over gAppADCMeasureCounter wakeup times */
-#ifndef gAppADCMeasureCounter_c 
+#ifndef gAppADCMeasureCounter_c
 #define gAppADCMeasureCounter_c         10
 #endif
 #else


### PR DESCRIPTION
Avoid redefinition of GPIO_BASE, already defined in npm1300 driver on which we don't have control